### PR TITLE
feat(data): extend data model (timers, messages, mesage subscriptions)

### DIFF
--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -1,0 +1,60 @@
+metadata:
+  labels:
+    agent: zeebe-ci-build
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: slaves
+  tolerations:
+    - key: "slaves"
+      operator: "Exists"
+      effect: "NoSchedule"
+  volumes:
+    - name: shared-data
+      emptyDir: {}
+  containers:
+    - name: maven
+      image: maven:3.6.0-jdk-11
+      command: ["cat"]
+      tty: true
+      env:
+        - name: LIMITS_CPU
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UseContainerSupport
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+        - name: ZEEBE_CI_SHARED_DATA
+          value: /home/shared
+      resources:
+        limits:
+          cpu: 8
+          memory: 32Gi
+        requests:
+          cpu: 8
+          memory: 32Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: shared-data
+          mountPath: /home/shared
+          mountPropagation: Bidirectional
+    - name: docker
+      image: docker:18.09.4-dind
+      args: ["--storage-driver=overlay2"]
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        limits:
+          cpu: 8
+          memory: 16Gi
+        requests:
+          cpu: 8
+          memory: 16Gi
+      volumeMounts:
+        - name: shared-data
+          mountPath: /home/shared
+          mountPropagation: Bidirectional

--- a/.ci/scripts/distribution/prepare.sh
+++ b/.ci/scripts/distribution/prepare.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -eux
+
+apt-get -qq update
+apt-get install --no-install-recommends -qq -y jq libatomic1
+
+useradd -u 1000 -m jenkins
+
+chmod -R a+x .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,32 +7,7 @@ pipeline {
       cloud 'zeebe-ci'
       label "zeebe-ci-build_${buildName}"
       defaultContainer 'jnlp'
-      yaml '''\
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    agent: zeebe-ci-build
-spec:
-  nodeSelector:
-    cloud.google.com/gke-nodepool: slaves
-  tolerations:
-    - key: "slaves"
-      operator: "Exists"
-      effect: "NoSchedule"
-  containers:
-    - name: maven
-      image: maven:3.6.0-jdk-11
-      command: ["cat"]
-      tty: true
-      resources:
-        limits:
-          cpu: 1
-          memory: 2Gi
-        requests:
-          cpu: 1
-          memory: 2Gi
-'''
+      yamlFile '.ci/podSpecs/distribution.yml'
     }
   }
 
@@ -57,8 +32,7 @@ spec:
       steps {
         container('maven') {
           configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-            sh 'apt-get update'
-            sh 'apt-get install --no-install-recommends -qq -y libatomic1'
+            sh '.ci/scripts/distribution/prepare.sh'
             sh 'mvn clean install -B -s $MAVEN_SETTINGS_XML -DskipTests'
           }
         }

--- a/README.md
+++ b/README.md
@@ -1,21 +1,49 @@
 ZeeQS - Zeebe Query Service
 =========================
 
-A [Zeebe](https://zeebe.io) community extension that provides a query API over Zeebe's data. The data is imported from the broker using an exporter (e.g. Hazelcast, Elasticsearch) and aggregated in the service. An application can access the data via GraphQL or REST API.
+A [Zeebe](https://zeebe.io) community extension that provides a GraphQL query API over Zeebe's data. The data is imported from the broker using an exporter (e.g. Hazelcast, Elasticsearch) and aggregated in the service.
 
 ![architecture view](docs/ZeeQS.png)
 
 ## Usage
 
-...
+The application provides an endpoint `/graphql` for GraphQL queries.
+
+A query can be send via HTTP GET request and a `query` parameter. For example, `localhost:9000/graphql?query={workflows{key,bpmnProcessId,version}}` 
+
+While development, the graph can be explored using the integrated GraphiQL:
+http://localhost:9000/graphiql
 
 ## Install
 
+### Docker
+
 ...
+
+### Manual
+
+1. Start Zeebe broker with Hazelcast Exporter (>= 0.8.0-alpha1)
+2. Start ZeeQS application
+  `java -jar zeeqs-1.0.0-SNAPSHOT.jar`
 
 ### Configuration
 
-...
+```
+# application database
+spring.datasource.url=jdbc:h2:mem:zeeqs;DB_CLOSE_DELAY=-1
+spring.datasource.user=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create
+
+server.port=9000
+
+# connection to Hazelcast
+io.zeebe.hazelcast.connection=localhost:5701
+
+# logging
+logging.level.io.zeebe.zeeqs=DEBUG
+logging.level.com.hazelcast=WARN
+```
 
 ## Build from Source
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>app</artifactId>
+  <name>ZeeQS - App</name>
 
   <dependencies>
 
@@ -39,14 +40,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   </dependencies>
+
+  <build>
+    <finalName>zeeqs-${project.version}</finalName>
+  </build>
 
 </project>

--- a/app/src/main/kotlin/io/zeebe/zeeqs/Application.kt
+++ b/app/src/main/kotlin/io/zeebe/zeeqs/Application.kt
@@ -1,21 +1,28 @@
 package io.zeebe.zeeqs
 
 import io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter
+import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 import javax.annotation.PostConstruct
 
 @SpringBootApplication
 @EnableCaching
+@EnableConfigurationProperties(HazelcastProperties::class)
 class ZeeqlApplication(
-        val importer: HazelcastImporter
+        val hazelcastProperties: HazelcastProperties,
+        val hazelcastImporter: HazelcastImporter
 ) {
+    val logger = LoggerFactory.getLogger(ZeeqlApplication::class.java)
 
     @PostConstruct
     fun init() {
-        println("importing from Hazelcast")
-        importer.start("localhost:5701")
+        val connection = hazelcastProperties.connection
+
+        logger.info("connect to Hazelcast: '$connection'")
+        hazelcastImporter.start(connection)
     }
 }
 

--- a/app/src/main/kotlin/io/zeebe/zeeqs/HazelcastProperties.kt
+++ b/app/src/main/kotlin/io/zeebe/zeeqs/HazelcastProperties.kt
@@ -1,0 +1,10 @@
+package io.zeebe.zeeqs
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties("io.zeebe.hazelcast")
+data class HazelcastProperties(
+        val connection: String = "localhost:5701"
+)

--- a/app/src/test/kotlin/io/zeebe/zeeqs/ApplicationTests.kt
+++ b/app/src/test/kotlin/io/zeebe/zeeqs/ApplicationTests.kt
@@ -1,13 +1,12 @@
 package io.zeebe.zeeqs
 
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest
 class ApplicationTests {
 
-	@Test
-	fun contextLoads() {
-	}
+    @Test
+    fun `empty test`() {
+        // modules are already tested
+    }
 
 }

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -12,6 +12,7 @@
   </parent>
 
   <artifactId>data</artifactId>
+  <name>ZeeQS - Data</name>
 
   <dependencies>
 
@@ -29,6 +30,25 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Message.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Message.kt
@@ -1,0 +1,17 @@
+package io.zeebe.zeeqs.data.entity
+
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+class Message(
+        @Id val key: Long,
+        val name: String,
+        val correlationKey: String?,
+        val messageId: String?,
+        val timeToLive: Long
+) {
+
+    var state: MessageState = MessageState.PUBLISHED
+    var timestamp: Long = -1
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageCorrelation.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageCorrelation.kt
@@ -1,0 +1,13 @@
+package io.zeebe.zeeqs.data.entity
+
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+class MessageCorrelation(
+        @Id val position: Long,
+        val messageKey: Long,
+        val messageName: String, // would favor subscriptionKey over message name + element instance key
+        val elementInstanceKey: Long,
+        val timestamp: Long
+)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageState.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageState.kt
@@ -1,0 +1,6 @@
+package io.zeebe.zeeqs.data.entity
+
+enum class MessageState {
+    PUBLISHED,
+    DELETED
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscription.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscription.kt
@@ -1,0 +1,19 @@
+package io.zeebe.zeeqs.data.entity
+
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+class MessageSubscription(
+        @Id val key: Long,
+        val messageName: String,
+        val messageCorrelationKey: String?,
+        val workflowInstanceKey: Long?,
+        val elementInstanceKey: Long?,
+        val workflowKey: Long?,
+        val elementId: String?
+) {
+
+    var state: MessageSubscriptionState = MessageSubscriptionState.OPENED
+    var timestamp: Long = -1
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscriptionState.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscriptionState.kt
@@ -1,0 +1,7 @@
+package io.zeebe.zeeqs.data.entity
+
+enum class MessageSubscriptionState {
+    OPENED,
+    CORRELATED,
+    CLOSED
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
@@ -1,0 +1,19 @@
+package io.zeebe.zeeqs.data.entity
+
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+class Timer(
+        @Id val key: Long,
+        val dueDate: Long,
+        var repetitions: Int,
+        val workflowInstanceKey: Long?,
+        val elementInstanceKey: Long?,
+        val workflowKey: Long?
+) {
+
+    var state: TimerState = TimerState.CREATED
+    var timestamp: Long = -1
+
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/TimerState.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/TimerState.kt
@@ -1,0 +1,7 @@
+package io.zeebe.zeeqs.data.entity
+
+enum class TimerState {
+    CREATED,
+    TRIGGERED,
+    CANCELED
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/MessageCorrelationRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/MessageCorrelationRepository.kt
@@ -1,0 +1,13 @@
+package io.zeebe.zeeqs.data.repository
+
+import io.zeebe.zeeqs.data.entity.MessageCorrelation
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MessageCorrelationRepository : PagingAndSortingRepository<MessageCorrelation, Long> {
+
+    fun findByMessageNameAndElementInstanceKey(messageName: String, elementInstanceKey: Long): List<MessageCorrelation>
+
+    fun findByMessageKey(messageKey: Long): List<MessageCorrelation>
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/MessageRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/MessageRepository.kt
@@ -1,0 +1,11 @@
+package io.zeebe.zeeqs.data.repository
+
+import io.zeebe.zeeqs.data.entity.Message
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MessageRepository : PagingAndSortingRepository<Message, Long> {
+
+
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/MessageSubscriptionRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/MessageSubscriptionRepository.kt
@@ -1,0 +1,20 @@
+package io.zeebe.zeeqs.data.repository
+
+import io.zeebe.zeeqs.data.entity.MessageSubscription
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MessageSubscriptionRepository : PagingAndSortingRepository<MessageSubscription, Long> {
+
+    fun findByWorkflowInstanceKey(workflowInstanceKey: Long): List<MessageSubscription>
+
+    fun findByElementInstanceKey(elementInstanceKey: Long): List<MessageSubscription>
+
+    fun findByWorkflowKey(workflowKey: Long): List<MessageSubscription>
+
+    fun findByElementInstanceKeyAndMessageName(elementInstanceKey: Long, messageName: String): MessageSubscription?
+
+    fun findByWorkflowKeyAndMessageName(workflowKey: Long, messageName: String): MessageSubscription?
+
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/TimerRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/TimerRepository.kt
@@ -1,0 +1,16 @@
+package io.zeebe.zeeqs.data.repository
+
+import io.zeebe.zeeqs.data.entity.Timer
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TimerRepository : PagingAndSortingRepository<Timer, Long> {
+
+    fun findByWorkflowInstanceKey(workflowInstanceKey: Long): List<Timer>
+
+    fun findByWorkflowKey(workflowKey: Long): List<Timer>
+
+    fun findByElementInstanceKey(elementInstanceKey: Long): List<Timer>
+
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/WorkflowInstanceRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/WorkflowInstanceRepository.kt
@@ -9,4 +9,5 @@ interface WorkflowInstanceRepository : PagingAndSortingRepository<WorkflowInstan
 
     fun findByParentWorkflowInstanceKey(parentWorkflowInstanceKey: Long): List<WorkflowInstance>
 
+    fun findByWorkflowKey(workflowKey: Long): List<WorkflowInstance>
 }

--- a/data/src/test/kotlin/io/zeebe/zeeqs/WorkflowServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/WorkflowServiceTest.kt
@@ -1,0 +1,70 @@
+package io.zeebe.zeeqs
+
+import io.zeebe.model.bpmn.Bpmn
+import io.zeebe.zeeqs.data.entity.Workflow
+import io.zeebe.zeeqs.data.repository.WorkflowRepository
+import io.zeebe.zeeqs.data.service.BpmnElementInfo
+import io.zeebe.zeeqs.data.service.WorkflowService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import java.time.Instant
+
+@SpringBootTest
+@TestConfiguration
+class WorkflowServiceTest(
+        @Autowired val workflowService: WorkflowService,
+        @Autowired val workflowRepository: WorkflowRepository
+) {
+
+    @Test
+    fun `should return element-id and element-name`() {
+        // given
+        val workflowKey = 1L
+
+        val bpmn = Bpmn.createExecutableProcess("wf")
+                .startEvent("s").name("start")
+                .serviceTask("t").name("task")
+                .zeebeTaskType("test")
+                .endEvent("e").name("")
+                .done()
+
+        workflowRepository.save(Workflow(
+                key = workflowKey,
+                bpmnProcessId = "wf",
+                version = 1,
+                bpmnXML = Bpmn.convertToString(bpmn),
+                timestamp = Instant.now().toEpochMilli()
+        ));
+
+        // when
+        val info = workflowService.getBpmnElementInfo(workflowKey)
+
+        // then
+        assertThat(info)
+                .isNotNull()
+                .contains(entry("s", BpmnElementInfo("s", "start")))
+                .contains(entry("t", BpmnElementInfo("t", "task")))
+                .contains(entry("e", BpmnElementInfo("e", null)))
+    }
+
+    @Test
+    fun `should return nothing if workflow does not exist`() {
+        // given
+        val workflowKey = 2L
+
+        // when
+        val info = workflowService.getBpmnElementInfo(workflowKey)
+
+        // then
+        assertThat(info).isNullOrEmpty()
+    }
+
+    @SpringBootApplication
+    class TestConfiguration
+
+}

--- a/graphql-api/pom.xml
+++ b/graphql-api/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>graphql-api</artifactId>
+  <name>ZeeQS - GraphQL API</name>
 
   <dependencies>
 
@@ -32,6 +33,24 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphiql-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/MessageQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/MessageQueryResolver.kt
@@ -1,0 +1,23 @@
+package io.zeebe.zeeqs.data.resolvers
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver
+import io.zeebe.zeeqs.data.entity.Message
+import io.zeebe.zeeqs.data.repository.MessageRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class MessageQueryResolver(
+        val messageRepository: MessageRepository
+) : GraphQLQueryResolver {
+
+    fun messages(count: Int, offset: Int): List<Message> {
+        return messageRepository.findAll(PageRequest.of(offset, count)).toList()
+    }
+
+    fun message(key: Long): Message? {
+        return messageRepository.findByIdOrNull(key)
+    }
+
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceResolver.kt
@@ -1,14 +1,8 @@
 package io.zeebe.zeeqs.data.resolvers
 
 import com.coxautodev.graphql.tools.GraphQLResolver
-import io.zeebe.zeeqs.data.entity.ElementInstance
-import io.zeebe.zeeqs.data.entity.ElementInstanceStateTransition
-import io.zeebe.zeeqs.data.entity.Incident
-import io.zeebe.zeeqs.data.entity.WorkflowInstance
-import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
-import io.zeebe.zeeqs.data.repository.ElementInstanceStateTransitionRepository
-import io.zeebe.zeeqs.data.repository.IncidentRepository
-import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
+import io.zeebe.zeeqs.data.entity.*
+import io.zeebe.zeeqs.data.repository.*
 import io.zeebe.zeeqs.data.service.WorkflowService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -19,7 +13,9 @@ class ElementInstanceResolver(
         val workflowInstanceRepository: WorkflowInstanceRepository,
         val incidentRepository: IncidentRepository,
         val elementInstanceStateTransitionRepository: ElementInstanceStateTransitionRepository,
-        val workflowService: WorkflowService
+        val timerRepository: TimerRepository,
+        val workflowService: WorkflowService,
+        val messageSubscriptionRepository: MessageSubscriptionRepository
 ) : GraphQLResolver<ElementInstance> {
 
     fun workflowInstance(elementInstance: ElementInstance): WorkflowInstance? {
@@ -43,6 +39,14 @@ class ElementInstanceResolver(
                 .getBpmnElementInfo(elementInstance.workflowKey)
                 ?.get(elementInstance.elementId)
                 ?.elementName
+    }
+
+    fun timers(elementInstance: ElementInstance): List<Timer> {
+        return timerRepository.findByElementInstanceKey(elementInstance.key)
+    }
+
+    fun messageSubscriptions(elementInstance: ElementInstance): List<MessageSubscription> {
+        return messageSubscriptionRepository.findByElementInstanceKey(elementInstance.key)
     }
 
 }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageCorrelationResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageCorrelationResolver.kt
@@ -1,0 +1,28 @@
+package io.zeebe.zeeqs.data.resolvers
+
+import com.coxautodev.graphql.tools.GraphQLResolver
+import io.zeebe.zeeqs.data.entity.Message
+import io.zeebe.zeeqs.data.entity.MessageCorrelation
+import io.zeebe.zeeqs.data.entity.MessageSubscription
+import io.zeebe.zeeqs.data.repository.MessageRepository
+import io.zeebe.zeeqs.data.repository.MessageSubscriptionRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class MessageCorrelationResolver(
+        val messageSubscriptionRepository: MessageSubscriptionRepository,
+        val messageRepository: MessageRepository
+) : GraphQLResolver<MessageCorrelation> {
+
+    fun messageSubscription(messageCorrelation: MessageCorrelation): MessageSubscription? {
+        return messageSubscriptionRepository.findByElementInstanceKeyAndMessageName(
+                elementInstanceKey = messageCorrelation.elementInstanceKey,
+                messageName = messageCorrelation.messageName
+        )
+    }
+
+    fun message(messageCorrelation: MessageCorrelation): Message? {
+        return messageRepository.findByIdOrNull(messageCorrelation.messageKey)
+    }
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageResolver.kt
@@ -1,0 +1,18 @@
+package io.zeebe.zeeqs.data.resolvers
+
+import com.coxautodev.graphql.tools.GraphQLResolver
+import io.zeebe.zeeqs.data.entity.Message
+import io.zeebe.zeeqs.data.entity.MessageCorrelation
+import io.zeebe.zeeqs.data.repository.MessageCorrelationRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MessageResolver(
+        val messageCorrelationRepository: MessageCorrelationRepository
+) : GraphQLResolver<Message> {
+
+    fun messageCorrelations(message: Message): List<MessageCorrelation> {
+        return messageCorrelationRepository.findByMessageKey(message.key)
+    }
+
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageSubscriptionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageSubscriptionResolver.kt
@@ -1,0 +1,42 @@
+package io.zeebe.zeeqs.data.resolvers
+
+import com.coxautodev.graphql.tools.GraphQLResolver
+import io.zeebe.zeeqs.data.entity.*
+import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
+import io.zeebe.zeeqs.data.repository.MessageCorrelationRepository
+import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
+import io.zeebe.zeeqs.data.repository.WorkflowRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class MessageSubscriptionResolver(
+        val workflowInstanceRepository: WorkflowInstanceRepository,
+        val elementInstanceRepository: ElementInstanceRepository,
+        val workflowRepository: WorkflowRepository,
+        val messageCorrelationRepository: MessageCorrelationRepository
+) : GraphQLResolver<MessageSubscription> {
+
+    fun workflowInstance(messageSubscription: MessageSubscription): WorkflowInstance? {
+        return messageSubscription.workflowInstanceKey?.let { workflowInstanceRepository.findByIdOrNull(it) }
+    }
+
+    fun elementInstance(messageSubscription: MessageSubscription): ElementInstance? {
+        return messageSubscription.elementInstanceKey?.let { elementInstanceRepository.findByIdOrNull(it) }
+    }
+
+    fun workflow(messageSubscription: MessageSubscription): Workflow? {
+        return messageSubscription.workflowKey?.let { workflowRepository.findByIdOrNull(it) }
+    }
+
+    fun messageCorrelations(messageSubscription: MessageSubscription): List<MessageCorrelation> {
+        return messageSubscription.elementInstanceKey
+                ?.let {
+                    messageCorrelationRepository.findByMessageNameAndElementInstanceKey(
+                            messageName = messageSubscription.messageName,
+                            elementInstanceKey = it)
+                }
+                ?: emptyList()
+    }
+
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
@@ -1,0 +1,33 @@
+package io.zeebe.zeeqs.graphql.resolvers.type
+
+import com.coxautodev.graphql.tools.GraphQLResolver
+import io.zeebe.zeeqs.data.entity.ElementInstance
+import io.zeebe.zeeqs.data.entity.Timer
+import io.zeebe.zeeqs.data.entity.Workflow
+import io.zeebe.zeeqs.data.entity.WorkflowInstance
+import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
+import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
+import io.zeebe.zeeqs.data.repository.WorkflowRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class TimerResolver(
+        val workflowRepository: WorkflowRepository,
+        val workflowInstanceRepository: WorkflowInstanceRepository,
+        val elementInstanceRepository: ElementInstanceRepository
+) : GraphQLResolver<Timer> {
+
+    fun workflow(timer: Timer): Workflow? {
+        return timer.workflowKey?.let { workflowRepository.findByIdOrNull(it) }
+    }
+
+    fun workflowInstance(timer: Timer): WorkflowInstance? {
+        return timer.workflowInstanceKey?.let { workflowInstanceRepository.findByIdOrNull(it) }
+    }
+
+    fun elementInstance(timer: Timer): ElementInstance? {
+        return timer.elementInstanceKey?.let { elementInstanceRepository.findByIdOrNull(it) }
+    }
+
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowInstanceResolver.kt
@@ -13,7 +13,9 @@ class WorkflowInstanceResolver(
         val workflowRepository: WorkflowRepository,
         val jobRepository: JobRepository,
         val incidentRepository: IncidentRepository,
-        val elementInstanceRepository: ElementInstanceRepository
+        val elementInstanceRepository: ElementInstanceRepository,
+        val timerRepository: TimerRepository,
+        val messageSubscriptionRepository: MessageSubscriptionRepository
 ) : GraphQLResolver<WorkflowInstance> {
 
     fun variables(workflowInstance: WorkflowInstance): List<Variable> {
@@ -42,6 +44,14 @@ class WorkflowInstanceResolver(
 
     fun elementInstances(workflowInstance: WorkflowInstance): List<ElementInstance> {
         return elementInstanceRepository.findByWorkflowInstanceKey(workflowInstance.key)
+    }
+
+    fun timers(workflowInstance: WorkflowInstance): List<Timer> {
+        return timerRepository.findByWorkflowInstanceKey(workflowInstance.key)
+    }
+
+    fun messageSubscriptions(workflowInstance: WorkflowInstance): List<MessageSubscription> {
+        return messageSubscriptionRepository.findByWorkflowInstanceKey(workflowInstance.key)
     }
 
 }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowResolver.kt
@@ -1,0 +1,32 @@
+package io.zeebe.zeeqs.graphql.resolvers.type
+
+import com.coxautodev.graphql.tools.GraphQLResolver
+import io.zeebe.zeeqs.data.entity.MessageSubscription
+import io.zeebe.zeeqs.data.entity.Timer
+import io.zeebe.zeeqs.data.entity.Workflow
+import io.zeebe.zeeqs.data.entity.WorkflowInstance
+import io.zeebe.zeeqs.data.repository.MessageSubscriptionRepository
+import io.zeebe.zeeqs.data.repository.TimerRepository
+import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
+import org.springframework.stereotype.Component
+
+@Component
+class WorkflowResolver(
+        val workflowInstanceRepository: WorkflowInstanceRepository,
+        val timerRepository: TimerRepository,
+        val messageSubscriptionRepository: MessageSubscriptionRepository
+) : GraphQLResolver<Workflow> {
+
+    fun workflowInstances(workflow: Workflow): List<WorkflowInstance> {
+        return workflowInstanceRepository.findByWorkflowKey(workflow.key)
+    }
+
+    fun timers(workflow: Workflow): List<Timer> {
+        return timerRepository.findByWorkflowKey(workflow.key)
+    }
+
+    fun messageSubscriptions(workflow: Workflow): List<MessageSubscription> {
+        return messageSubscriptionRepository.findByWorkflowKey(workflow.key)
+    }
+
+}

--- a/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
@@ -15,9 +15,13 @@ type ElementInstance {
     startTime: Long
     endTime: Long
 
+    stateTransitions: [ElementInstanceStateTransition]
+
     incidents: [Incident!]
 
-    stateTransitions: [ElementInstanceStateTransition]
+    timers: [Timer!]
+
+    messageSubscriptions: [MessageSubscription!]
 }
 
 type ElementInstanceStateTransition {

--- a/graphql-api/src/main/resources/graphql/Message.graphqls
+++ b/graphql-api/src/main/resources/graphql/Message.graphqls
@@ -1,0 +1,24 @@
+type Message {
+    key: ID!
+
+    name: String!
+    correlationKey: String
+    messageId: String
+    timeToLive: Long,
+
+    state: MessageState
+    timestamp: Long
+
+    messageCorrelations: [MessageCorrelation!]
+}
+
+enum MessageState {
+    PUBLISHED
+    DELETED
+}
+
+extend type Query {
+    message(key: ID!): Message
+
+    messages(count: Int = 10, offset: Int = 0): [Message!]!
+}

--- a/graphql-api/src/main/resources/graphql/MessageSubscription.graphqls
+++ b/graphql-api/src/main/resources/graphql/MessageSubscription.graphqls
@@ -1,0 +1,29 @@
+type MessageSubscription {
+    key: ID!
+
+    messageName: String!
+    messageCorrelationKey: String
+
+    workflowInstance: WorkflowInstance
+    elementInstance: ElementInstance
+
+    workflow: Workflow
+
+    state: MessageSubscriptionState
+    timestamp: Long
+
+    messageCorrelations: [MessageCorrelation!]
+}
+
+type MessageCorrelation {
+    messageSubscription: MessageSubscription
+    message: Message
+    timestamp: Long
+}
+
+enum MessageSubscriptionState {
+    OPENED
+    CORRELATED
+    CLOSED
+}
+

--- a/graphql-api/src/main/resources/graphql/Timer.graphqls
+++ b/graphql-api/src/main/resources/graphql/Timer.graphqls
@@ -1,0 +1,22 @@
+type Timer {
+    key: ID!
+
+    dueDate: Long
+    repetitions: Int
+
+    workflowInstance: WorkflowInstance
+    elementInstance: ElementInstance
+
+    workflow: Workflow
+
+    state: TimerState!
+    timestamp: Long!
+}
+
+enum TimerState {
+    CREATED
+    TRIGGERED
+    CANCELED
+}
+
+

--- a/graphql-api/src/main/resources/graphql/Workflow.graphqls
+++ b/graphql-api/src/main/resources/graphql/Workflow.graphqls
@@ -5,6 +5,12 @@ type Workflow {
     timestamp: Long!
 
     bpmnXML: String!
+
+    workflowInstances: [WorkflowInstance!]
+
+    timers: [Timer!]
+
+    messageSubscriptions: [MessageSubscription!]
 }
 
 extend type Query {

--- a/graphql-api/src/main/resources/graphql/WorkflowInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/WorkflowInstance.graphqls
@@ -20,6 +20,10 @@ type WorkflowInstance {
     childWorkflowInstances: [WorkflowInstance!]
 
     elementInstances: [ElementInstance!]
+
+    timers: [Timer!]
+
+    messageSubscriptions: [MessageSubscription!]
 }
 
 enum WorkflowInstanceState {

--- a/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlTest.kt
+++ b/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlTest.kt
@@ -1,0 +1,71 @@
+package io.zeebe.zeeqs
+
+import io.zeebe.zeeqs.data.entity.Workflow
+import io.zeebe.zeeqs.data.repository.WorkflowRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.core.env.Environment
+import org.springframework.core.env.get
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestConfiguration
+class ZeebeGraphqlTest(
+        @Autowired val environment: Environment,
+        @Autowired val workflowRepository: WorkflowRepository) {
+
+    val serverPort = environment.get("local.server.port")
+
+    @Test
+    fun `should query workflow`() {
+        // given
+        workflowRepository.save(Workflow(
+                key = 1,
+                bpmnProcessId = "wf",
+                version = 1,
+                bpmnXML = "<...>",
+                timestamp = Instant.now().toEpochMilli()
+        ));
+
+        // when
+        val response = sendQuery("{workflows{key,bpmnProcessId,version}}")
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200)
+        assertThat(response.body()).isEqualToIgnoringWhitespace("""
+            {"data":
+            {"workflows":[
+            {"key":"1",
+            "bpmnProcessId":"wf", 
+            "version":1}
+            ]}}""".trimIndent())
+    }
+
+    private fun sendQuery(query: String): HttpResponse<String> {
+        val encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8)
+        val uri = "http://localhost:$serverPort/graphql?query=$encodedQuery"
+
+        val request = HttpRequest.newBuilder()
+                .uri(URI(uri))
+                .GET()
+                .build()
+
+        return HttpClient
+                .newHttpClient()
+                .send(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    @SpringBootApplication
+    class TestConfiguration
+
+}

--- a/hazelcast-importer/pom.xml
+++ b/hazelcast-importer/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>hazelcast-importer</artifactId>
+  <name>ZeeQS - Hazelcast Importer</name>
 
   <dependencies>
     <dependency>
@@ -21,6 +22,42 @@
     <dependency>
       <groupId>io.zeebe.hazelcast</groupId>
       <artifactId>zeebe-hazelcast-connector</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/hazelcast-importer/src/test/kotlin/io/zeebe/zeeqs/HazelcastImporterTest.kt
+++ b/hazelcast-importer/src/test/kotlin/io/zeebe/zeeqs/HazelcastImporterTest.kt
@@ -1,0 +1,92 @@
+package io.zeebe.zeeqs
+
+import io.zeebe.client.ZeebeClient
+import io.zeebe.containers.ZeebeBrokerContainer
+import io.zeebe.containers.ZeebePort
+import io.zeebe.model.bpmn.Bpmn
+import io.zeebe.zeeqs.data.repository.WorkflowRepository
+import io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.MountableFile
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+
+@SpringBootTest
+@Testcontainers
+class HazelcastImporterTest(
+        @Autowired val importer: HazelcastImporter,
+        @Autowired val workflowRepository: WorkflowRepository) {
+
+    val exporterJarPath: Path = Paths.get("../target/exporter/zeebe-hazelcast-exporter.jar")
+    val containerPath = "/usr/local/zeebe/exporter/zeebe-hazelcast-exporter.jar"
+
+    val hazelcastPort = 5701
+
+    @Container
+    var zeebe = ZeebeBrokerContainer("0.22.1")
+            .withConfigurationResource("zeebe.cfg.toml")
+            .withCopyFileToContainer(MountableFile.forHostPath(exporterJarPath), containerPath)
+            .withExposedPorts(hazelcastPort)
+
+    @BeforeEach
+    fun init() {
+        assertThat(exporterJarPath).exists()
+    }
+
+    @Test
+    fun `should import workflow`() {
+        // given
+        val port = zeebe.getMappedPort(hazelcastPort)
+        importer.start("localhost:$port")
+
+        val client = ZeebeClient.newClientBuilder()
+                .brokerContactPoint(zeebe.getExternalAddress(ZeebePort.GATEWAY))
+                .usePlaintext()
+                .build()
+
+        // when
+        client.newDeployCommand()
+                .addWorkflowModel(
+                        Bpmn.createExecutableProcess("wf")
+                                .startEvent()
+                                .serviceTask("task-1").zeebeTaskType("test")
+                                .endEvent()
+                                .done(),
+                        "wf.bpmn")
+                .send()
+                .join()
+
+        // verify
+        waitUntilWorkflowIsImported()
+
+        assertThat(workflowRepository.findAll()).hasSize(1)
+
+        val workflow = workflowRepository.findAll().toList()[0]
+        assertThat(workflow.key).isGreaterThan(0)
+        assertThat(workflow.bpmnProcessId).isEqualTo("wf")
+        assertThat(workflow.version).isEqualTo(1)
+        assertThat(workflow.timestamp).isGreaterThan(0)
+        assertThat(workflow.bpmnXML).isNotEmpty()
+    }
+
+    private fun waitUntilWorkflowIsImported() {
+        val timeout = Instant.now().plus(Duration.ofSeconds(10))
+        while (workflowRepository.count() < 1 && Instant.now().isBefore(timeout)) {
+            Thread.sleep(10)
+        }
+    }
+
+    @SpringBootApplication
+    class TestConfiguration
+}
+
+

--- a/hazelcast-importer/src/test/resources/zeebe.cfg.toml
+++ b/hazelcast-importer/src/test/resources/zeebe.cfg.toml
@@ -1,0 +1,4 @@
+[[exporters]]
+id = "hazelcast"
+className = "io.zeebe.hazelcast.exporter.HazelcastExporter"
+jarPath = "exporter/zeebe-hazelcast-exporter.jar"

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <groupId>io.zeebe.zeeqs</groupId>
   <artifactId>zeeqs-root</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <name>Zeebe Query Service</name>
+  <name>ZeeQS - Root</name>
   <description>Query API for aggregated Zeebe data</description>
 
   <modules>
@@ -32,9 +32,11 @@
     <zeebe.version>0.22.1</zeebe.version>
 
     <spring.boot.version>2.2.3.RELEASE</spring.boot.version>
-    <hazelcast.exporter.version>0.7.0</hazelcast.exporter.version>
+    <hazelcast.exporter.version>0.8.0-alpha1</hazelcast.exporter.version>
     <graphql.version>5.0.2</graphql.version>
     <graphql.tools.version>5.2.4</graphql.tools.version>
+    <zeebe-test-container.version>0.32.0</zeebe-test-container.version>
+    <test-container.version>1.12.5</test-container.version>
 
     <!-- release parent settings -->
     <version.java>11</version.java>
@@ -110,9 +112,22 @@
         <version>${graphql.tools.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.zeebe</groupId>
+        <artifactId>zeebe-test-container</artifactId>
+        <version>${zeebe-test-container.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${test-container.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
+  <!-- common dependencies -->
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
@@ -160,6 +175,27 @@
             <version>${kotlin.version}</version>
           </dependency>
         </dependencies>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
       </plugin>
 
       <plugin>
@@ -176,6 +212,38 @@
         <configuration>
           <!-- Override java source version to workaround javadoc bug https://bugs.openjdk.java.net/browse/JDK-8212233 -->
           <source>8</source>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <artifactItems>
+            <artifactItem>
+              <groupId>io.zeebe.hazelcast</groupId>
+              <artifactId>zeebe-hazelcast-exporter</artifactId>
+              <version>${hazelcast.exporter.version}</version>
+              <type>jar</type>
+              <classifier>jar-with-dependencies</classifier>
+              <overWrite>true</overWrite>
+              <outputDirectory>${project.build.directory}/exporter</outputDirectory>
+              <destFileName>zeebe-hazelcast-exporter.jar</destFileName>
+            </artifactItem>
+          </artifactItems>
+          <outputDirectory>${project.build.directory}/libs</outputDirectory>
+          <overWriteReleases>false</overWriteReleases>
+          <overWriteSnapshots>true</overWriteSnapshots>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </modules>
 
   <properties>
-    <kotlin.version>1.3.61</kotlin.version>
+    <kotlin.version>1.3.70</kotlin.version>
 
     <zeebe.version>0.22.1</zeebe.version>
 
@@ -132,10 +132,12 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-reflect</artifactId>
+      <version>${kotlin.version}</version>
     </dependency>
   </dependencies>
 
@@ -153,6 +155,7 @@
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
         <configuration>
           <args>
             <arg>-Xjsr305=strict</arg>


### PR DESCRIPTION
* import timers, messages and message subscriptions from Hazelcast
* extend GraphQL API
* dump `hazelcast.exporter.version` to `0.8.0-alpha1`

closes #1 
closes #2 
closes #3 