### PR TITLE
feat(graphql): return ISO8601 string instead of timestamp

### DIFF
--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceResolver.kt
@@ -4,6 +4,7 @@ import com.coxautodev.graphql.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.*
 import io.zeebe.zeeqs.data.service.WorkflowService
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -17,6 +18,14 @@ class ElementInstanceResolver(
         val workflowService: WorkflowService,
         val messageSubscriptionRepository: MessageSubscriptionRepository
 ) : GraphQLResolver<ElementInstance> {
+
+    fun startTime(elementInstance: ElementInstance, zoneId: String): String? {
+        return elementInstance.startTime?.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+    fun endTime(elementInstance: ElementInstance, zoneId: String): String? {
+        return elementInstance.endTime?.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
 
     fun workflowInstance(elementInstance: ElementInstance): WorkflowInstance? {
         return workflowInstanceRepository.findByIdOrNull(elementInstance.workflowInstanceKey)

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceStateTransitionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceStateTransitionResolver.kt
@@ -1,0 +1,15 @@
+package io.zeebe.zeeqs.data.resolvers
+
+import com.coxautodev.graphql.tools.GraphQLResolver
+import io.zeebe.zeeqs.data.entity.ElementInstanceStateTransition
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
+import org.springframework.stereotype.Component
+
+@Component
+class ElementInstanceStateTransitionResolver : GraphQLResolver<ElementInstanceStateTransition> {
+
+    fun timestamp(elementInstanceStateTransition: ElementInstanceStateTransition, zoneId: String): String? {
+        return elementInstanceStateTransition.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/IncidentResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/IncidentResolver.kt
@@ -8,6 +8,7 @@ import io.zeebe.zeeqs.data.entity.WorkflowInstance
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.JobRepository
 import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -17,6 +18,14 @@ class IncidentResolver(
         val jobRepository: JobRepository,
         val elementInstanceRepository: ElementInstanceRepository
 ) : GraphQLResolver<Incident> {
+
+    fun creationTime(incident: Incident, zoneId: String): String? {
+        return incident.creationTime?.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+    fun resolveTime(incident: Incident, zoneId: String): String? {
+        return incident.resolveTime?.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
 
     fun workflowInstance(incident: Incident): WorkflowInstance? {
         return workflowInstanceRepository.findByIdOrNull(incident.workflowInstanceKey)

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/JobResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/JobResolver.kt
@@ -1,13 +1,11 @@
 package io.zeebe.zeeqs.data.resolvers
 
 import com.coxautodev.graphql.tools.GraphQLResolver
-import io.zeebe.zeeqs.data.entity.ElementInstance
-import io.zeebe.zeeqs.data.entity.Incident
-import io.zeebe.zeeqs.data.entity.Job
-import io.zeebe.zeeqs.data.entity.WorkflowInstance
+import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.IncidentRepository
 import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -17,6 +15,10 @@ class JobResolver(
         val incidentRepository: IncidentRepository,
         val elementInstanceRepository: ElementInstanceRepository
 ) : GraphQLResolver<Job> {
+
+    fun timestamp(job: Job, zoneId: String): String? {
+        return job.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
 
     fun workflowInstance(job: Job): WorkflowInstance? {
         return workflowInstanceRepository.findByIdOrNull(job.workflowInstanceKey)

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageCorrelationResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageCorrelationResolver.kt
@@ -6,6 +6,7 @@ import io.zeebe.zeeqs.data.entity.MessageCorrelation
 import io.zeebe.zeeqs.data.entity.MessageSubscription
 import io.zeebe.zeeqs.data.repository.MessageRepository
 import io.zeebe.zeeqs.data.repository.MessageSubscriptionRepository
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -14,6 +15,10 @@ class MessageCorrelationResolver(
         val messageSubscriptionRepository: MessageSubscriptionRepository,
         val messageRepository: MessageRepository
 ) : GraphQLResolver<MessageCorrelation> {
+
+    fun timestamp(messageCorrelation: MessageCorrelation, zoneId: String): String? {
+        return messageCorrelation.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
 
     fun messageSubscription(messageCorrelation: MessageCorrelation): MessageSubscription? {
         return messageSubscriptionRepository.findByElementInstanceKeyAndMessageName(

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageResolver.kt
@@ -3,13 +3,24 @@ package io.zeebe.zeeqs.data.resolvers
 import com.coxautodev.graphql.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Message
 import io.zeebe.zeeqs.data.entity.MessageCorrelation
+import io.zeebe.zeeqs.data.entity.MessageSubscription
 import io.zeebe.zeeqs.data.repository.MessageCorrelationRepository
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.stereotype.Component
+import java.time.Duration
 
 @Component
 class MessageResolver(
         val messageCorrelationRepository: MessageCorrelationRepository
 ) : GraphQLResolver<Message> {
+
+    fun timestamp(message: Message, zoneId: String): String? {
+        return message.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+    fun timeToLive(message: Message): String? {
+        return message.timeToLive.let { Duration.ofMillis(it).toString() }
+    }
 
     fun messageCorrelations(message: Message): List<MessageCorrelation> {
         return messageCorrelationRepository.findByMessageKey(message.key)

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageSubscriptionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageSubscriptionResolver.kt
@@ -6,6 +6,7 @@ import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.MessageCorrelationRepository
 import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
 import io.zeebe.zeeqs.data.repository.WorkflowRepository
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -16,6 +17,10 @@ class MessageSubscriptionResolver(
         val workflowRepository: WorkflowRepository,
         val messageCorrelationRepository: MessageCorrelationRepository
 ) : GraphQLResolver<MessageSubscription> {
+
+    fun timestamp(messageSubscription: MessageSubscription, zoneId: String): String? {
+        return messageSubscription.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
 
     fun workflowInstance(messageSubscription: MessageSubscription): WorkflowInstance? {
         return messageSubscription.workflowInstanceKey?.let { workflowInstanceRepository.findByIdOrNull(it) }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ResolverExtension.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ResolverExtension.kt
@@ -1,0 +1,15 @@
+package io.zeebe.zeeqs.graphql.resolvers.type
+
+import java.time.Instant
+import java.time.ZoneId
+
+object ResolverExtension {
+
+    fun timestampToString(timestamp: Long, zoneId: String): String {
+        val instant = Instant.ofEpochMilli(timestamp)
+        val zone = ZoneId.of(zoneId)
+        val zonedDateTime = instant.atZone(zone)
+        val offsetDateTime = zonedDateTime.toOffsetDateTime()
+        return offsetDateTime.toString()
+    }
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
@@ -1,10 +1,7 @@
 package io.zeebe.zeeqs.graphql.resolvers.type
 
 import com.coxautodev.graphql.tools.GraphQLResolver
-import io.zeebe.zeeqs.data.entity.ElementInstance
-import io.zeebe.zeeqs.data.entity.Timer
-import io.zeebe.zeeqs.data.entity.Workflow
-import io.zeebe.zeeqs.data.entity.WorkflowInstance
+import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
 import io.zeebe.zeeqs.data.repository.WorkflowRepository
@@ -17,6 +14,14 @@ class TimerResolver(
         val workflowInstanceRepository: WorkflowInstanceRepository,
         val elementInstanceRepository: ElementInstanceRepository
 ) : GraphQLResolver<Timer> {
+
+    fun timestamp(timer: Timer, zoneId: String): String? {
+        return timer.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+    fun dueDate(timer: Timer, zoneId: String): String? {
+        return timer.dueDate.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
 
     fun workflow(timer: Timer): Workflow? {
         return timer.workflowKey?.let { workflowRepository.findByIdOrNull(it) }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableResolver.kt
@@ -6,6 +6,7 @@ import io.zeebe.zeeqs.data.entity.Variable
 import io.zeebe.zeeqs.data.entity.VariableUpdate
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.VariableUpdateRepository
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -14,6 +15,10 @@ class VariableResolver(
         val variableUpdateRepository: VariableUpdateRepository,
         val elementInstanceRepository: ElementInstanceRepository
 ) : GraphQLResolver<Variable> {
+
+    fun timestamp(variable: Variable, zoneId: String): String? {
+        return variable.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
 
     fun updates(variable: Variable): List<VariableUpdate> {
         return variableUpdateRepository.findByVariableKey(variable.key)

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableUpdateResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableUpdateResolver.kt
@@ -1,0 +1,15 @@
+package io.zeebe.zeeqs.data.resolvers
+
+import com.coxautodev.graphql.tools.GraphQLResolver
+import io.zeebe.zeeqs.data.entity.VariableUpdate
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
+import org.springframework.stereotype.Component
+
+@Component
+class VariableUpdateResolver : GraphQLResolver<VariableUpdate> {
+
+    fun timestamp(variableUpdate: VariableUpdate, zoneId: String): String? {
+        return variableUpdate.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+}

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowInstanceResolver.kt
@@ -3,6 +3,7 @@ package io.zeebe.zeeqs.data.resolvers
 import com.coxautodev.graphql.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.*
+import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension.timestampToString
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
@@ -17,6 +18,14 @@ class WorkflowInstanceResolver(
         val timerRepository: TimerRepository,
         val messageSubscriptionRepository: MessageSubscriptionRepository
 ) : GraphQLResolver<WorkflowInstance> {
+
+    fun startTime(workflowInstance: WorkflowInstance, zoneId: String): String? {
+        return workflowInstance.startTime?.let { timestampToString(it, zoneId) }
+    }
+
+    fun endTime(workflowInstance: WorkflowInstance, zoneId: String): String? {
+        return workflowInstance.endTime?.let { timestampToString(it, zoneId) }
+    }
 
     fun variables(workflowInstance: WorkflowInstance): List<Variable> {
         return variableRepository.findByWorkflowInstanceKey(workflowInstance.key)

--- a/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
@@ -12,8 +12,8 @@ type ElementInstance {
 
     scope: ElementInstance
 
-    startTime: Long
-    endTime: Long
+    startTime(zoneId: String = "Z"): String
+    endTime(zoneId: String = "Z"): String
 
     stateTransitions: [ElementInstanceStateTransition]
 
@@ -26,7 +26,7 @@ type ElementInstance {
 
 type ElementInstanceStateTransition {
     state: ElementInstanceState!
-    timestamp: Long
+    timestamp(zoneId: String = "Z"): String
 }
 
 enum ElementInstanceState {

--- a/graphql-api/src/main/resources/graphql/Incident.graphqls
+++ b/graphql-api/src/main/resources/graphql/Incident.graphqls
@@ -6,8 +6,8 @@ type Incident {
 
     state: IncidentState!
 
-    creationTime: Long
-    resolveTime: Long
+    creationTime(zoneId: String = "Z"): String
+    resolveTime(zoneId: String = "Z"): String
 
     workflowInstance: WorkflowInstance
     elementInstance: ElementInstance

--- a/graphql-api/src/main/resources/graphql/Job.graphqls
+++ b/graphql-api/src/main/resources/graphql/Job.graphqls
@@ -7,7 +7,7 @@ type Job {
     retries: Int
 
     state: JobState!
-    timestamp: Long!
+    timestamp(zoneId: String = "Z"): String!
 
     workflowInstance: WorkflowInstance
     elementInstance: ElementInstance

--- a/graphql-api/src/main/resources/graphql/Message.graphqls
+++ b/graphql-api/src/main/resources/graphql/Message.graphqls
@@ -4,10 +4,10 @@ type Message {
     name: String!
     correlationKey: String
     messageId: String
-    timeToLive: Long,
+    timeToLive: String,
 
     state: MessageState
-    timestamp: Long
+    timestamp(zoneId: String = "Z"): String
 
     messageCorrelations: [MessageCorrelation!]
 }

--- a/graphql-api/src/main/resources/graphql/MessageSubscription.graphqls
+++ b/graphql-api/src/main/resources/graphql/MessageSubscription.graphqls
@@ -10,7 +10,7 @@ type MessageSubscription {
     workflow: Workflow
 
     state: MessageSubscriptionState
-    timestamp: Long
+    timestamp(zoneId: String = "Z"): String
 
     messageCorrelations: [MessageCorrelation!]
 }
@@ -18,7 +18,7 @@ type MessageSubscription {
 type MessageCorrelation {
     messageSubscription: MessageSubscription
     message: Message
-    timestamp: Long
+    timestamp(zoneId: String = "Z"): String
 }
 
 enum MessageSubscriptionState {

--- a/graphql-api/src/main/resources/graphql/Timer.graphqls
+++ b/graphql-api/src/main/resources/graphql/Timer.graphqls
@@ -1,7 +1,7 @@
 type Timer {
     key: ID!
 
-    dueDate: Long
+    dueDate(zoneId: String = "Z"): String
     repetitions: Int
 
     workflowInstance: WorkflowInstance
@@ -10,7 +10,7 @@ type Timer {
     workflow: Workflow
 
     state: TimerState!
-    timestamp: Long!
+    timestamp(zoneId: String = "Z"): String!
 }
 
 enum TimerState {

--- a/graphql-api/src/main/resources/graphql/Variable.graphqls
+++ b/graphql-api/src/main/resources/graphql/Variable.graphqls
@@ -5,12 +5,12 @@ type Variable {
 
     scope: ElementInstance
 
-    timestamp: Long!
+    timestamp(zoneId: String = "Z"): String!
 
     updates: [VariableUpdate!]
 }
 
 type VariableUpdate {
     value: String!
-    timestamp: Long!
+    timestamp(zoneId: String = "Z"): String!
 }

--- a/graphql-api/src/main/resources/graphql/WorkflowInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/WorkflowInstance.graphqls
@@ -7,9 +7,9 @@ type WorkflowInstance {
     parentElementInstance: ElementInstance
 
     # the time when the workflow instance was created
-    startTime: Long
+    startTime(zoneId: String = "Z"): String
     # the time when the workflow instance was ended (completed/terminated)
-    endTime: Long
+    endTime(zoneId: String = "Z"): String
 
     # the workflow the instance is created of
     workflow: Workflow

--- a/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
+++ b/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
@@ -42,7 +42,9 @@ class HazelcastImporter(
         val clientConfig = ClientConfig()
         val networkConfig = clientConfig.networkConfig
         networkConfig.addresses = listOf(hazelcastConnection)
-        networkConfig.connectionTimeout = Duration.ofSeconds(60).toMillis().toInt()
+        // networkConfig.connectionAttemptPeriod = Duration.ofSeconds(10).toMillis().toInt()
+        // networkConfig.connectionAttemptLimit = 10
+        // networkConfig.connectionTimeout = Duration.ofSeconds(10).toMillis().toInt()
 
         val hazelcast = HazelcastClient.newHazelcastClient(clientConfig)
 


### PR DESCRIPTION
* instead of returning a timestamp as long, using the ISO8601 date-time string format
* the zone-id can be passed via optional argument