### PR TITLE
feat(data): add start and end time for timers and jobs

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Job.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Job.kt
@@ -14,6 +14,9 @@ class Job(
     var state: JobState = JobState.ACTIVATABLE
     var timestamp: Long = -1
 
+    var startTime: Long? = null
+    var endTime: Long? = null
+
     var retries: Int? = null
     var worker: String? = null
 

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
@@ -14,6 +14,8 @@ class Timer(
 ) {
 
     var state: TimerState = TimerState.CREATED
-    var timestamp: Long = -1
+
+    var startTime: Long? = null
+    var endTime: Long? = null
 
 }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/JobResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/JobResolver.kt
@@ -1,7 +1,10 @@
 package io.zeebe.zeeqs.data.resolvers
 
 import com.coxautodev.graphql.tools.GraphQLResolver
-import io.zeebe.zeeqs.data.entity.*
+import io.zeebe.zeeqs.data.entity.ElementInstance
+import io.zeebe.zeeqs.data.entity.Incident
+import io.zeebe.zeeqs.data.entity.Job
+import io.zeebe.zeeqs.data.entity.WorkflowInstance
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.IncidentRepository
 import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
@@ -18,6 +21,14 @@ class JobResolver(
 
     fun timestamp(job: Job, zoneId: String): String? {
         return job.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+    fun startTime(job: Job, zoneId: String): String? {
+        return job.startTime?.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+    fun endTime(job: Job, zoneId: String): String? {
+        return job.endTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
     fun workflowInstance(job: Job): WorkflowInstance? {

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
@@ -1,7 +1,10 @@
 package io.zeebe.zeeqs.graphql.resolvers.type
 
 import com.coxautodev.graphql.tools.GraphQLResolver
-import io.zeebe.zeeqs.data.entity.*
+import io.zeebe.zeeqs.data.entity.ElementInstance
+import io.zeebe.zeeqs.data.entity.Timer
+import io.zeebe.zeeqs.data.entity.Workflow
+import io.zeebe.zeeqs.data.entity.WorkflowInstance
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.WorkflowInstanceRepository
 import io.zeebe.zeeqs.data.repository.WorkflowRepository
@@ -15,8 +18,12 @@ class TimerResolver(
         val elementInstanceRepository: ElementInstanceRepository
 ) : GraphQLResolver<Timer> {
 
-    fun timestamp(timer: Timer, zoneId: String): String? {
-        return timer.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
+    fun startTime(timer: Timer, zoneId: String): String? {
+        return timer.startTime?.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
+    fun endTime(timer: Timer, zoneId: String): String? {
+        return timer.endTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
     fun dueDate(timer: Timer, zoneId: String): String? {

--- a/graphql-api/src/main/resources/graphql/Job.graphqls
+++ b/graphql-api/src/main/resources/graphql/Job.graphqls
@@ -9,6 +9,11 @@ type Job {
     state: JobState!
     timestamp(zoneId: String = "Z"): String!
 
+    # the time when the job was created
+    startTime(zoneId: String = "Z"): String
+    # the time when the job was removed (completed/error-thrown/canceled)
+    endTime(zoneId: String = "Z"): String
+
     workflowInstance: WorkflowInstance
     elementInstance: ElementInstance
 

--- a/graphql-api/src/main/resources/graphql/Timer.graphqls
+++ b/graphql-api/src/main/resources/graphql/Timer.graphqls
@@ -10,7 +10,11 @@ type Timer {
     workflow: Workflow
 
     state: TimerState!
-    timestamp(zoneId: String = "Z"): String!
+
+    # the time when the timer subscription was created
+    startTime(zoneId: String = "Z"): String
+    # the time when the timer subscritpion was removed (triggered/cancled)
+    endTime(zoneId: String = "Z"): String
 }
 
 enum TimerState {

--- a/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
+++ b/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
@@ -340,12 +340,20 @@ class HazelcastImporter(
                 .orElse(createTimer(record))
 
         when (record.metadata.intent) {
-            "CREATED" -> entity.state = TimerState.CREATED
-            "TRIGGERED" -> entity.state = TimerState.TRIGGERED
-            "CANCELED" -> entity.state = TimerState.CANCELED
+            "CREATED" -> {
+                entity.state = TimerState.CREATED
+                entity.startTime = record.metadata.timestamp
+            }
+            "TRIGGERED" -> {
+                entity.state = TimerState.TRIGGERED
+                entity.endTime = record.metadata.timestamp
+            }
+            "CANCELED" -> {
+                entity.state = TimerState.CANCELED
+                entity.endTime = record.metadata.timestamp
+            }
         }
 
-        entity.timestamp = record.metadata.timestamp
         entity.repetitions = record.repetitions
 
         timerRepository.save(entity)

--- a/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
+++ b/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
@@ -280,12 +280,25 @@ class HazelcastImporter(
                 .orElse(createJob(record))
 
         when (record.metadata.intent) {
-            "CREATED", "TIMED_OUT", "RETRIES_UPDATED" -> entity.state = JobState.ACTIVATABLE
+            "CREATED" -> {
+                entity.state = JobState.ACTIVATABLE
+                entity.startTime = record.metadata.timestamp
+            }
+            "TIMED_OUT", "RETRIES_UPDATED" -> entity.state = JobState.ACTIVATABLE
             "ACTIVATED" -> entity.state = JobState.ACTIVATED
             "FAILED" -> entity.state = JobState.FAILED
-            "COMPLETED" -> entity.state = JobState.COMPLETED
-            "CANCELED" -> entity.state = JobState.CANCELED
-            "ERROR_THROWN" -> entity.state = JobState.ERROR_THROWN
+            "COMPLETED" -> {
+                entity.state = JobState.COMPLETED
+                entity.endTime = record.metadata.timestamp
+            }
+            "CANCELED" -> {
+                entity.state = JobState.CANCELED
+                entity.endTime = record.metadata.timestamp
+            }
+            "ERROR_THROWN" -> {
+                entity.state = JobState.ERROR_THROWN
+                entity.endTime = record.metadata.timestamp
+            }
         }
 
         entity.worker = record.worker.ifEmpty { null }


### PR DESCRIPTION
* replace the timer's timestamp with a start and an end time
* add a start and end time to the job
* expose start and end time via GraphQL

closes #19 