### PR TITLE
fix(graphql): return deployment time as ISO-8601 string

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Workflow.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Workflow.kt
@@ -10,4 +10,4 @@ data class Workflow(
         val bpmnProcessId: String,
         val version: Int,
         @Lob val bpmnXML: String,
-        val timestamp: Long)
+        val deployTime: Long)

--- a/data/src/test/kotlin/io/zeebe/zeeqs/WorkflowServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/WorkflowServiceTest.kt
@@ -38,7 +38,7 @@ class WorkflowServiceTest(
                 bpmnProcessId = "wf",
                 version = 1,
                 bpmnXML = Bpmn.convertToString(bpmn),
-                timestamp = Instant.now().toEpochMilli()
+                deployTime = Instant.now().toEpochMilli()
         ));
 
         // when

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/WorkflowResolver.kt
@@ -14,6 +14,10 @@ class WorkflowResolver(
         val messageSubscriptionRepository: MessageSubscriptionRepository
 ) : GraphQLResolver<Workflow> {
 
+    fun deployTime(workflow: Workflow, zoneId: String): String? {
+        return workflow.deployTime.let { ResolverExtension.timestampToString(it, zoneId) }
+    }
+
     fun workflowInstances(workflow: Workflow, stateIn: List<WorkflowInstanceState>): List<WorkflowInstance> {
         return workflowInstanceRepository.findByWorkflowKeyAndStateIn(workflow.key, stateIn)
     }

--- a/graphql-api/src/main/resources/graphql/Workflow.graphqls
+++ b/graphql-api/src/main/resources/graphql/Workflow.graphqls
@@ -6,7 +6,7 @@ type Workflow {
     # the deployed version of the workflow based on the BPMN process id
     version: Int!
     # the time when the workflow was deployed
-    timestamp: Long!
+    deployTime(zoneId: String = "Z"): String!
     # the BPMN XML of the workflow
     bpmnXML: String!
     # the created instances of the workflow

--- a/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlTest.kt
+++ b/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlTest.kt
@@ -34,7 +34,7 @@ class ZeebeGraphqlTest(
                 bpmnProcessId = "wf",
                 version = 1,
                 bpmnXML = "<...>",
-                timestamp = Instant.now().toEpochMilli()
+                deployTime = Instant.now().toEpochMilli()
         ));
 
         // when

--- a/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
+++ b/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
@@ -99,7 +99,7 @@ class HazelcastImporter(
                 bpmnProcessId = workflow.bpmnProcessId,
                 version = workflow.version,
                 bpmnXML = resource.resource.toStringUtf8(),
-                timestamp = deployment.metadata.timestamp
+                deployTime = deployment.metadata.timestamp
         )
     }
 

--- a/hazelcast-importer/src/test/kotlin/io/zeebe/zeeqs/HazelcastImporterTest.kt
+++ b/hazelcast-importer/src/test/kotlin/io/zeebe/zeeqs/HazelcastImporterTest.kt
@@ -74,7 +74,7 @@ class HazelcastImporterTest(
         assertThat(workflow.key).isGreaterThan(0)
         assertThat(workflow.bpmnProcessId).isEqualTo("wf")
         assertThat(workflow.version).isEqualTo(1)
-        assertThat(workflow.timestamp).isGreaterThan(0)
+        assertThat(workflow.deployTime).isGreaterThan(0)
         assertThat(workflow.bpmnXML).isNotEmpty()
     }
 


### PR DESCRIPTION
* unify deployment time to return a string instead of long timestamp
* rename timestamp to deployTime
